### PR TITLE
Handling "Ignore and go to next form" button on required fields dialog

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -144,11 +144,6 @@ class ExternalModule extends AbstractExternalModule {
         $forms_access = $this->getFormsAccessMatrix($arm, $record, $settings['config']);
 
         if ($record && $event_id && $instrument) {
-            if (!$forms_access[$record][$event_id][$instrument]) {
-                // Access denied to the current page.
-                redirect(APP_PATH_WEBROOT . 'DataEntry/record_home.php?pid=' . $Proj->project_id . '&id=' . $record . '&arm=' . $arm);
-            }
-
             $instruments = array_keys($forms_access[$record][$event_id]);
             $curr_forms_access = $forms_access[$record][$event_id];
 
@@ -163,6 +158,17 @@ class ExternalModule extends AbstractExternalModule {
                 }
 
                 $i++;
+            }
+
+            // Access denied to the current page.
+            if (!$forms_access[$record][$event_id][$instrument]) {
+                // Redirecting to the next step.
+                if (!$redirect_path = $next_step_path) {
+                    // If there is no next step available, go to record home page.
+                    $redirect_path = APP_PATH_WEBROOT . 'DataEntry/record_home.php?pid=' . $Proj->project_id . '&id=' . $record . '&arm=' . $arm;
+                }
+
+                redirect($redirect_path);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the functional specification at [https://docs.google.com/document/d/1Ej7vCNp
 - REDCap >= 8.0.3
 
 ## Installation
-- Clone this repo into to `<redcap-root>/modules/form_render_skip_logic_v2.0`.
+- Clone this repo into to `<redcap-root>/modules/form_render_skip_logic_v<version_number>`.
 - Go to **Control Center > Manage External Modules** and enable Form Render Skip Logic.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Form Render Skip Logic for that project.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The original use case of this tool was to facilitate a data entry workflow speci
 See the functional specification at [https://docs.google.com/document/d/1Ej7vCNpKOrC6X9KVpkZkHeY0v2VqQXrjuMIBQtbj1bw/edit#](https://docs.google.com/document/d/1Ej7vCNpKOrC6X9KVpkZkHeY0v2VqQXrjuMIBQtbj1bw/edit) for functional details.
 
 ## Prerequisites
-- REDCap >= 8.0.0 (for versions < 8.0.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
+- REDCap >= 8.0.3
 
 ## Installation
 - Clone this repo into to `<redcap-root>/modules/form_render_skip_logic_v2.0`.

--- a/config.json
+++ b/config.json
@@ -10,37 +10,37 @@
         {
             "name": "Philip Chase",
             "email": "pbc@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Taryn Stoffs",
             "email": "tls@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Prasad Lanka",
             "email": "planka@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Surya Prasanna",
             "email": "suryayalla@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Dileep Rajput",
             "email": "rajputd@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Stewart Wehmeyer",
             "email": "swehmeyer@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Tiago Bember",
             "email": "tbembersimeao@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         }
     ],
     "project-settings": [
@@ -81,5 +81,8 @@
                 }
             ]
         }
-    ]
+    ],
+    "compatibility": {
+        "redcap-version-min": "8.0.3"
+    }
 }

--- a/js/rfsl.js
+++ b/js/rfsl.js
@@ -131,7 +131,11 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         else {
             // Disable button inside the dropdown menu.
-            $('a[onclick="dataEntrySubmit(\'submit-btn-' + buttonName + '\');return false;"]').hide();
+            // Obs.: yes, this is a weird selector - "#" prefix is not being
+            // used - but this approach is needed on this page because there
+            // are multiple DOM elements with the same ID - which is
+            // totally wrong.
+            $('a[id="submit-btn-' + buttonName + '"]').hide();
         }
     }
 });

--- a/js/rfsl.js
+++ b/js/rfsl.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
             $('[id="submit-btn-savenextform"]').attr('onclick', 'formRenderSkipLogic.saveNextForm()');
         }
         else {
-            removeButtons('savecontinue');
+            removeButtons('savenextform');
         }
 
         // Handling "Ignore and go to next form" button on required fields

--- a/js/rfsl.js
+++ b/js/rfsl.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     switch (formRenderSkipLogic.location) {
         case 'data_entry_form':
-            overrideNextFormButtonRedirect();
+            overrideNextFormButtonsRedirect();
             $links = $('.formMenuList a');
             break;
         case 'record_home':
@@ -30,16 +30,48 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     /**
-     * Overrides next form button to redirect to the next available step.
+     * Overrides next form buttons to redirect to the next available step.
      */
-    function overrideNextFormButtonRedirect() {
-        if (!formRenderSkipLogic.nextStepPath) {
+    function overrideNextFormButtonsRedirect() {
+        // Handling "Save & Go to Next Form" button.
+        if (formRenderSkipLogic.nextStepPath) {
+            formRenderSkipLogic.saveNextForm = function() {
+                appendHiddenInputToForm('save-and-redirect', formRenderSkipLogic.nextStepPath);
+                dataEntrySubmit('submit-btn-savecontinue');
+                return false;
+            }
+
+            // Overriding submit callback.
+            $('[id="submit-btn-savenextform"]').attr('onclick', 'formRenderSkipLogic.saveNextForm()');
+        }
+        else {
             removeButtons('savecontinue');
-            return;
         }
 
-        var newSubmit = 'appendHiddenInputToForm(\'save-and-redirect\', formRenderSkipLogic.nextStepPath); dataEntrySubmit(\'submit-btn-savecontinue\'); return false;';
-        $('a[onclick="dataEntrySubmit(\'submit-btn-savenextform\');return false;"]').attr('onclick', newSubmit);
+        // Handling "Ignore and go to next form" button on required fields
+        // dialog.
+        $('#reqPopup').on('dialogopen', function(event, ui) {
+            var buttons = $(this).dialog('option', 'buttons');
+
+            $.each(buttons, function(i, button) {
+                if (button.name !== 'Ignore and go to next form') {
+                    return;
+                }
+
+                if (formRenderSkipLogic.nextStepPath) {
+                    buttons[i] = function() {
+                        window.location.href = formRenderSkipLogic.nextStepPath;
+                    };
+                }
+                else {
+                    delete buttons[i];
+                }
+
+                return false;
+            });
+
+            $(this).dialog('option', 'buttons', buttons);
+        });
     }
 
     /**


### PR DESCRIPTION
Review steps:
- [x] Make sure FRSL is **enabled** for your project
- [x] Make sure [LDEW](http://github.com/ctsit/linear_data_entry_workflow) is **disabled** for your project
- [x] Configure FRSL in order to disable 2 instruments of a given event:
1. any middle one (it cannot also be the penultimate);
2. the last one
- [x] Make sure the previous instrument to the disabled fields contain required fields
- [x] Go to the instrument which is the previous to the middle one, leave a few required fields blank  (make sure to change at least one field), then submit
- [x] Once the warning modal appears, click on "Ignore and go to next form", and make sure you are redirected correctly, i.e. the disabled instrument was skipped
- [x] Go to the penultimate instrument, leave a few required fields blank (make sure to change at least one field), then click at any bullet at the left menu (in order to exit the current page)
- [x] Once the warning modal appears, click on "Save changes and leave"
- [x] Once the 2nd warning modal appears, make sure you do not see the button "Ignore and go to next form" in the modal
- [x] Make sure there are no regressions on "Save & Go To Next Form" button behavior (i.e. it redirects correctly and it does not show up at the last enabled instrument)