### PR TITLE
Feature/add migration from 2.x to 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to the Form Render Skip Logic module will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0] - 2018-06-29
+### Added
+- Add support for migrating FRSL v2.x.x configurations to FRSL v3.x.x configurations automatically (Dileep Rajput)
+
 ## [3.1.1] - 2018-06-04
 ### Changed
 - Fixing control field's 2nd column visibility. (Tiago Bember Simeao)

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -480,6 +480,22 @@ class ExternalModule extends AbstractExternalModule {
     }
 
     /**
+     * checks if FRSL version 2.X settings exist.
+     */
+     function CheckIfVersion2SettingsExist() {
+       $module_id = $this->getFRSLModuleId();
+
+       //search for existing 2.X settings
+       $q = "SELECT 1 FROM redcap_external_module_settings WHERE external_module_id='$module_id' AND `key` IN ('control_field', 'event_name', 'event_name', 'field_name', 'enabled_before_ctrl_field_is_set', 'target_instruments', 'instrument_name', 'control_field_value');";
+       $result = $this->query($q);
+
+       //if we got something return true, otherwise false
+       $settings_exist = !empty($result->fetch_assoc());
+
+       return $settings_exist;
+     }
+
+    /**
      * gets external module_id for FRSL.
      * cannot use ExternalModules::getIdForPrefix() because it is private.
      */

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -622,27 +622,16 @@ class ExternalModule extends AbstractExternalModule {
        $module_id = $this->getFRSLModuleId();
 
        foreach ($settings as $project_id => $setting) {
-         /*creates all of the local variables used in the VALUES clause in the
-         statement below*/
-         extract($setting);
+         $q = "INSERT INTO redcap_external_module_settings (external_module_id, project_id, `key`, type, value) VALUES ";
 
-         $q = "INSERT INTO redcap_external_module_settings
-                (external_module_id, project_id, `key`, type, value)
-              VALUES
-                ($module_id, $project_id, 'control_fields', 'json-array', '$control_fields'),
-                ($module_id, $project_id, 'control_mode', 'json-array', '$control_mode'),
-                ($module_id, $project_id, 'control_event_id', 'json-array', '$control_event_id'),
-                ($module_id, $project_id, 'control_field_key', 'json-array', '$control_field_key'),
-                ($module_id, $project_id, 'control_piping', 'json-array', '$control_piping'),
-                ($module_id, $project_id, 'control_default_value', 'json-array', '$control_default_value'),
-                ($module_id, $project_id, 'branching_logic', 'json-array', '$branching_logic'),
-                ($module_id, $project_id, 'condition_value', 'json-array', '$condition_value'),
-                ($module_id, $project_id, 'condition_operator', 'json-array', '$condition_operator'),
-                ($module_id, $project_id, 'target_forms', 'json-array', '$target_forms'),
-                ($module_id, $project_id, 'target_events_select', 'json-array', '$target_events_select'),
-                ($module_id, $project_id, 'target_events', 'json-array', '$target_events')";
+         //build query
+         $values_to_insert = [];
+         foreach ($setting as $key => $value) {
+           $values_to_insert[] = "($module_id, $project_id, '$key', 'json-array', '$value')";
+         }
 
-          $this->query($q);
+         $q .= join(",", $values_to_insert);
+         $this->query($q);
        }
      }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -486,7 +486,7 @@ class ExternalModule extends AbstractExternalModule {
        $module_id = $this->getFRSLModuleId();
 
        //search for existing 2.X settings
-       $q = "SELECT 1 FROM redcap_external_module_settings WHERE external_module_id='$module_id' AND `key` IN ('control_field', 'event_name', 'event_name', 'field_name', 'enabled_before_ctrl_field_is_set', 'target_instruments', 'instrument_name', 'control_field_value');";
+       $q = "SELECT 1 FROM redcap_external_module_settings WHERE external_module_id='$module_id' AND `key` IN ('control_field', 'event_name', 'event_name', 'field_name', 'enabled_before_ctrl_field_is_set', 'target_instruments', 'instrument_name', 'control_field_value')";
        $result = $this->query($q);
 
        //if we got something return true, otherwise false
@@ -501,10 +501,35 @@ class ExternalModule extends AbstractExternalModule {
      */
      function getFRSLModuleId() {
        $q = "SELECT external_module_id FROM redcap_external_modules where directory_prefix = '" . $this->PREFIX . "'" ;
-
        $result = $this->query($q);
        $id = $result->fetch_assoc()['external_module_id'];
 
        return $id;
      }
+
+    /**
+     * gets FRSLv2.x.x settings for each as an associative array indexed by
+     * project_id, where each project setting is an associative array indexed by
+     * setting name and maps to a setting value
+     * @return array $settings
+     */
+     function getV2XSettings() {
+       $module_id = $this->getFRSLModuleId();
+
+       //get old settings data
+       $q = "SELECT project_id, `key`, value FROM redcap_external_module_settings WHERE external_module_id='$module_id' AND `key` IN ('control_field', 'event_name', 'event_name', 'field_name', 'enabled_before_ctrl_field_is_set', 'target_instruments', 'instrument_name', 'control_field_value')";
+       $result = $this->query($q);
+
+       //create data stucture to represent old settings data
+       $settings = [];
+       while($row = $result->fetch_assoc()) {
+         $project_id = $row["project_id"];
+         $key = $row["key"];
+         $value = $row["value"];
+         $settings[$project_id][$key] = $value;
+       }
+
+       return $settings;
+     }
+
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -88,26 +88,14 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_module_system_change_version($version, $old_version) {
-        //migrate settings only if version 2 settings exist and version 3 settings
-        //do not exist.
-        if ($this->checkIfVersionSettingsExist("v2.0.0") && !$this->checkIfVersionSettingsExist("v3.0.0")) {
-            $old_setting = $this->getV2Settings();
-            $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
-            $this->storeV3Settings($new_setting);
-        }
+        $this->migrateSettings();
     }
 
     /**
      * @inheritdoc
      */
     function redcap_module_system_enable($version) {
-        //migrate settings only if version 2 settings exist and version 3 settings
-        //do not exist.
-        if ($this->checkIfVersionSettingsExist("v2.0.0") && !$this->checkIfVersionSettingsExist("v3.0.0")) {
-            $old_setting = $this->getV2Settings();
-            $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
-            $this->storeV3Settings($new_setting);
-        }
+        $this->migrateSettings();
     }
 
     /**
@@ -648,5 +636,20 @@ class ExternalModule extends AbstractExternalModule {
          $q .= join(",", $values_to_insert);
          $this->query($q);
        }
+     }
+
+     /**
+      * migrates stored module settings from v2.x.x to v3.x.x if needed.
+      * @param none.
+      * @return none.
+      */
+     function migrateSettings() {
+         //migrate settings only if version 2 settings exist and version 3 settings
+         //do not exist.
+         if ($this->checkIfVersionSettingsExist("v2.0.0") && !$this->checkIfVersionSettingsExist("v3.0.0")) {
+             $old_setting = $this->getV2Settings();
+             $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
+             $this->storeV3Settings($new_setting);
+         }
      }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -532,4 +532,66 @@ class ExternalModule extends AbstractExternalModule {
        return $settings;
      }
 
+    /**
+     * converts settings from from FRSL_v2.X to FRSL_v3.X
+     * @param array $old_settings, array of v2 settings indexed by project_id
+     * @return array $new_settings, array of v3 settings indexed by project_id
+     */
+     function convert2XSettingsTo3XSettings($old_settings) {
+       $module_id = $this->getFRSLModuleId();
+
+       //use old_settings to create new_settings
+       $new_settings = [];
+       foreach ($old_settings as $project_id => $old_setting) {
+
+         //generate some of the new settings using the old "instrument_name" values
+         $old_instrument_names = json_decode($old_setting["instrument_name"]);
+         $old_instrument_count = count($old_instrument_names);
+         $branching_logic = [];
+         $condition_operator = [];
+         $target_forms = [];
+         $target_events_select = [];
+         $target_events = [];
+
+         for($i = 0; $i < $old_instrument_count; $i++) {
+           $branching_logic[] = true;
+           $condition_operator[] = null;
+           $target_forms[] = [$old_instrument_names[$i]];
+           $target_events_select[] = false;
+           $target_events[] = [null];
+         }
+
+         //convert to nested JSON-arrays for storage
+         $branching_logic = "[" . json_encode($branching_logic) . "]";
+         $condition_operator = "[" . json_encode($condition_operator) . "]";
+         $target_forms = "[" . json_encode($target_forms) . "]";
+         $target_events_select =  "[" . json_encode($target_events_select) . "]";
+         $target_events = "[" . json_encode($target_events) . "]";
+
+         //create sub-structure for project setting
+         $setting = [];
+
+         /*added extra angle brackets around some values because every new config
+          is stored as a JSON-array or as a nested JSON-array*/
+         $setting["control_fields"] = $old_setting["control_field"];
+         $setting["control_mode"] = '["default"]';
+         $setting["control_event_id"] = $old_setting["event_name"];
+         $setting["control_field_key"] = $old_setting["field_name"];
+         $setting["control_piping"] = "[null]";
+         $setting["control_default_value"] = "[null]";
+         $setting["branching_logic"] = $branching_logic;
+         $setting["condition_value"] = "[" . $old_setting["control_field_value"] . "]";
+         $setting["condition_operator"] = $condition_operator;
+         $setting["target_forms"] = $target_forms;
+         $setting["target_events_select"] = $target_events_select;
+         $setting["target_events"] = $target_events;
+
+         //store in main data structure
+         $new_settings[$project_id] = $setting;
+       }
+
+       return $new_settings;
+
+     }
+
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -478,4 +478,17 @@ class ExternalModule extends AbstractExternalModule {
 
         return $formatted;
     }
+
+    /**
+     * gets external module_id for FRSL.
+     * cannot use ExternalModules::getIdForPrefix() because it is private.
+     */
+     function getFRSLModuleId() {
+       $q = "SELECT external_module_id FROM redcap_external_modules where directory_prefix = '" . $this->PREFIX . "'" ;
+
+       $result = $this->query($q);
+       $id = $result->fetch_assoc()['external_module_id'];
+
+       return $id;
+     }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -88,11 +88,26 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_module_system_change_version($version, $old_version) {
-      if (preg_match("/v3\.[0-9]+(\.[0-9]+)?/", $version) && preg_match("/v2\.[0-9]+(\.[0-9]+)?/", $old_version) && $this->checkIfVersionSettingsExist($old_version) && !$this->checkIfVersionSettingsExist($version)) {
-        $old_setting = $this->getV2Settings();
-        $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
-        $this->storeV3Settings($new_setting);
-      }
+        //migrate settings only if version 2 settings exist and version 3 settings
+        //do not exist.
+        if ($this->checkIfVersionSettingsExist("v2.0.0") && !$this->checkIfVersionSettingsExist("v3.0.0")) {
+            $old_setting = $this->getV2Settings();
+            $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
+            $this->storeV3Settings($new_setting);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function redcap_module_system_enable($version) {
+        //migrate settings only if version 2 settings exist and version 3 settings
+        //do not exist.
+        if ($this->checkIfVersionSettingsExist("v2.0.0") && !$this->checkIfVersionSettingsExist("v3.0.0")) {
+            $old_setting = $this->getV2Settings();
+            $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
+            $this->storeV3Settings($new_setting);
+        }
     }
 
     /**

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -88,7 +88,7 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_module_system_change_version($version, $old_version) {
-      if (preg_match("/v3\.*/", $version) && preg_match("/v2\.*/", $old_version) && $this->checkIfVersionSettingsExist($old_version)) {
+      if (preg_match("/v3\.[0-9]+(\.[0-9]+)?/", $version) && preg_match("/v2\.[0-9]+(\.[0-9]+)?/", $old_version) && $this->checkIfVersionSettingsExist($old_version)) {
         $old_setting = $this->getV2XSettings();
         $new_setting = $this->convert2XSettingsTo3XSettings($old_setting);
         $this->store3XSettings($new_setting);

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -89,9 +89,9 @@ class ExternalModule extends AbstractExternalModule {
      */
     function redcap_module_system_change_version($version, $old_version) {
       if (preg_match("/v3\.[0-9]+(\.[0-9]+)?/", $version) && preg_match("/v2\.[0-9]+(\.[0-9]+)?/", $old_version) && $this->checkIfVersionSettingsExist($old_version) && !$this->checkIfVersionSettingsExist($version)) {
-        $old_setting = $this->getV2XSettings();
-        $new_setting = $this->convert2XSettingsTo3XSettings($old_setting);
-        $this->store3XSettings($new_setting);
+        $old_setting = $this->getV2Settings();
+        $new_setting = $this->convertV2SettingsToV3Settings($old_setting);
+        $this->storeV3Settings($new_setting);
       }
     }
 
@@ -535,7 +535,7 @@ class ExternalModule extends AbstractExternalModule {
      * setting name and maps to a setting value
      * @return array $settings
      */
-     function getV2XSettings() {
+     function getV2Settings() {
        $module_id = $this->getFRSLModuleId();
 
        //get old settings data
@@ -559,7 +559,7 @@ class ExternalModule extends AbstractExternalModule {
      * @param array $old_settings, array of v2 settings indexed by project_id
      * @return array $new_settings, array of v3 settings indexed by project_id
      */
-     function convert2XSettingsTo3XSettings($old_settings) {
+     function convertV2SettingsToV3Settings($old_settings) {
        $new_settings = [];
        foreach ($old_settings as $project_id => $old_setting) {
 
@@ -618,7 +618,7 @@ class ExternalModule extends AbstractExternalModule {
       * @param array $settings, array of v3 settings indexed by project_id and
       * maps to a array of setting keys pointing to their associated values.
       */
-     function store3XSettings($settings) {
+     function storeV3Settings($settings) {
        $module_id = $this->getFRSLModuleId();
 
        foreach ($settings as $project_id => $setting) {

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -85,6 +85,17 @@ class ExternalModule extends AbstractExternalModule {
     }
 
     /**
+     * @inheritdoc
+     */
+    function redcap_module_system_change_version($version, $old_version) {
+      if (preg_match("/v3\.*/", $version) && preg_match("/v2\.*/", $old_version) && $this->CheckIfVersion2SettingsExist()) {
+        $old_setting = $this->getV2XSettings();
+        $new_setting = $this->convert2XSettingsTo3XSettings($old_setting);
+        $this->store3XSettings($new_setting);
+      }
+    }
+
+    /**
      * Gets forms access matrix.
      *
      * @param string $arm

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -591,4 +591,36 @@ class ExternalModule extends AbstractExternalModule {
 
      }
 
+     /**
+      * stores FRSL_v3.X created by convert2XSettingsTo3XSettings method into db
+      * @param array $settings, array of v3 settings indexed by project_id and
+      * maps to a array of setting keys pointing to their associated values.
+      */
+     function store3XSettings($settings) {
+       $module_id = $this->getFRSLModuleId();
+
+       foreach ($settings as $project_id => $setting) {
+         /*creates all of the local variables used in the VALUES clause in the
+         statement below*/
+         extract($setting);
+
+         $q = "INSERT INTO redcap_external_module_settings
+                (external_module_id, project_id, `key`, type, value)
+              VALUES
+                ($module_id, $project_id, 'control_fields', 'json-array', '$control_fields'),
+                ($module_id, $project_id, 'control_mode', 'json-array', '$control_mode'),
+                ($module_id, $project_id, 'control_event_id', 'json-array', '$control_event_id'),
+                ($module_id, $project_id, 'control_field_key', 'json-array', '$control_field_key'),
+                ($module_id, $project_id, 'control_piping', 'json-array', '$control_piping'),
+                ($module_id, $project_id, 'control_default_value', 'json-array', '$control_default_value'),
+                ($module_id, $project_id, 'branching_logic', 'json-array', '$branching_logic'),
+                ($module_id, $project_id, 'condition_value', 'json-array', '$condition_value'),
+                ($module_id, $project_id, 'condition_operator', 'json-array', '$condition_operator'),
+                ($module_id, $project_id, 'target_forms', 'json-array', '$target_forms'),
+                ($module_id, $project_id, 'target_events_select', 'json-array', '$target_events_select'),
+                ($module_id, $project_id, 'target_events', 'json-array', '$target_events')";
+
+          $this->query($q);
+       }
+     }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -538,9 +538,6 @@ class ExternalModule extends AbstractExternalModule {
      * @return array $new_settings, array of v3 settings indexed by project_id
      */
      function convert2XSettingsTo3XSettings($old_settings) {
-       $module_id = $this->getFRSLModuleId();
-
-       //use old_settings to create new_settings
        $new_settings = [];
        foreach ($old_settings as $project_id => $old_setting) {
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -88,7 +88,7 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_module_system_change_version($version, $old_version) {
-      if (preg_match("/v3\.[0-9]+(\.[0-9]+)?/", $version) && preg_match("/v2\.[0-9]+(\.[0-9]+)?/", $old_version) && $this->checkIfVersionSettingsExist($old_version)) {
+      if (preg_match("/v3\.[0-9]+(\.[0-9]+)?/", $version) && preg_match("/v2\.[0-9]+(\.[0-9]+)?/", $old_version) && $this->checkIfVersionSettingsExist($old_version) && !$this->checkIfVersionSettingsExist($version)) {
         $old_setting = $this->getV2XSettings();
         $new_setting = $this->convert2XSettingsTo3XSettings($old_setting);
         $this->store3XSettings($new_setting);

--- a/README.md
+++ b/README.md
@@ -40,10 +40,4 @@ See [Animal Identification Example](samples/Animal_Identification.md) for a work
 
 ## Upgrading From Version 2.x - 3.x
 
-Note that version 3.0.0 introduced a breaking change in the configuration. To execute the upgrade you will need to follow these steps:
-
-* Note the projects that use FRSL
-* Record the configuration of each project
-* Erase the configuration of each project
-* Upgrade FRSL to 3.x
-* Re-enter the configuration for each project
+Note that version 3.0.0 introduced a breaking change in the configuration. When you upgrade to version 3.x all of your old configurations in 2.x will be converted into the 3.x configuration scheme. This migration only occurs the first time you upgrade from 2.x to 3.x . Thereafter, if you decided to switch back and forth between the two versions, your configurations will not transfer. This is to ensure that all of your old 2.x configurations will still be available to you if you decide to go back to version 2.x .

--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
         "redcap_every_page_top",
         "redcap_data_entry_form_top",
         "redcap_survey_page_top",
-        "redcap_save_record"
+        "redcap_save_record",
+        "redcap_module_system_change_version"
     ],
     "authors": [
         {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
         "redcap_data_entry_form_top",
         "redcap_survey_page_top",
         "redcap_save_record",
-        "redcap_module_system_change_version"
+        "redcap_module_system_change_version",
+        "redcap_module_system_enable"
     ],
     "authors": [
         {


### PR DESCRIPTION
### Review steps:
- [ ] Install the 2.x.x version of this module alongside the version in this pull request.
- [ ] Enable the 2.x.x version in the control center and then enable it on a project.
- [ ] Insert some configuration settings for the 2.x.x version of this module in the above project.
- [ ] Observe the module's modules behavior and make note of it.
- [ ] Go to the control center and upgrade FRSL to the version in this pull request.
- [ ] Return to the project that you where originally on earlier and observe that the module's behavior has not changed.
- [ ] Go to the module's configuration page for that project and verify that configurations equivalent to the 2.x.x version have appeared.
- [ ] Verify that when you switch back to the 2.x.x version none of your old configuration settings are lost.
- [ ] Verify that this feature is properly documented in the README and CHANGELOG.