### PR TITLE
Fixing wrong behavior of "Control mode" field on config form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to the Form Render Skip Logic module will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.3.2] - 2018-08-14
+### Changed
+- Fix wrong behavior of "Control mode" field on config form. (Tiago Bember Simeao)
+
+
 ## [3.3.1] - 2018-08-13
 ### Changed
 - Refactor 2.x - 3.x migration in order to use External Modules API functions. (Tiago Bember Simeao)

--- a/js/config.js
+++ b/js/config.js
@@ -79,18 +79,13 @@ $(document).ready(function() {
             });
 
             $modal.find('tr[field="control_mode"]').each(function() {
-                var defaultValue = 'default';
-                $(this).find('.external-modules-input-element').each(function() {
-                    // Not using ":checked" selector to get the selected radio
-                    // due to a possible bug on EM that unchecks radios within
-                    // repeatable elements.
-                    if (typeof this.attributes.checked !== 'undefined') {
-                        defaultValue = $(this).val();
-                        return false;
-                    }
-                });
+                var $checked = $(this).find('.external-modules-input-element:checked');
 
-                branchingLogicRadios($(this).find('.external-modules-input-element[value="' + defaultValue + '"]'));
+                if ($checked.length === 0) {
+                    $checked = $(this).find('.external-modules-input-element[value="default"]');
+                }
+
+                branchingLogicRadios($checked);
             });
 
             $modal.find('tr[field="control_mode"] .external-modules-input-element').change(function() {


### PR DESCRIPTION
This PR fixes a non expected reset of "control mode" fields on config form when any "+" button is clicked.

Review steps:
- [x] Go to FRSL config form
- [x] Set at least one control field as "Advanced" (make that there are no branching logic regressions)
- [x] Click on "+" buttons a few times and make sure the existing radio boxes selections do not not change (i.e. remain set as Advanced)