### PR TITLE
Fixing wrong behavior of "Control mode" field on config form: part II

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -82,7 +82,18 @@ $(document).ready(function() {
                 var $checked = $(this).find('.external-modules-input-element:checked');
 
                 if ($checked.length === 0) {
-                    $checked = $(this).find('.external-modules-input-element[value="default"]');
+                    $(this).find('.external-modules-input-element').each(function() {
+                        // This is a workaround for an EM bug that does not load
+                        // radios default values properly.
+                        if (typeof this.attributes.checked !== 'undefined') {
+                            $checked = $(this);
+                            return false;
+                        }
+                    });
+
+                    if ($checked.length === 0) {
+                        $checked = $(this).find('.external-modules-input-element[value="default"]');
+                    }
                 }
 
                 branchingLogicRadios($checked);


### PR DESCRIPTION
Review steps:
- [ ] Save a FRSL form containing at least 2 advanced modes enabled
- [ ] Re-open FRSL form, and make sure your selections persist
- [ ] Reload page and repeat the previous step
- [ ] Click on "+" buttons a few times and make sure your selections persist (and the new control fields are set as "default")