### PR TITLE
add text under radio option warning of slowdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Access **Manage External Modules** section of your project, click on Form Render
 The top level entry in the configuration is a Control Field. A control field is described by either:
 
 1. a selected event-field pair _or_
-2. a text that describes an equation, working as a [calculated field](https://www.ctsi.ufl.edu/files/2017/06/Calculated-Fields-%E2%80%93-REDCap-How.pdf) (you may use Piping and smart variables)
+2. a text that describes an equation, working as a [calculated field](https://www.ctsi.ufl.edu/files/2017/06/Calculated-Fields-%E2%80%93-REDCap-How.pdf) (you may use Piping and smart variables)\*  
+
+\* This option causes slowdowns on important REDCap pages in large projects and will be removed in a future version.
 
 ![advanced control field](img/advanced_control_field.png)
 

--- a/config.json
+++ b/config.json
@@ -60,7 +60,7 @@
                         },
                         {
                             "value": "advanced",
-                            "name": "Advanced (Equation with Piping and/or Smart Variables)"
+                            "name": "Advanced (Equation with Piping and/or Smart Variables).</br><small style=\"color:red\">Warning: this feature may cause slowdowns, please use default if possible.<small>"
                         }
                     ]
                 },

--- a/config.json
+++ b/config.json
@@ -60,7 +60,7 @@
                         },
                         {
                             "value": "advanced",
-                            "name": "Advanced (Equation with Piping and/or Smart Variables).</br><small style=\"color:red\">Warning: this feature may cause slowdowns, please use default if possible.<small>"
+                            "name": "Advanced (Equation with Piping and/or Smart Variables).</br><small style=\"color:red\">Warning: this feature is deprecated. It will be removed in a future version of this module.<small>"
                         }
                     ]
                 },

--- a/css/config.css
+++ b/css/config.css
@@ -21,3 +21,12 @@
 .frsl-piping-helper {
     margin-left: 10px;
 }
+
+.external-modules-input-td {
+    white-space: nowrap;
+}
+
+.external-modules-input-td label {
+    display: inline-block;
+    vertical-align: top;
+}


### PR DESCRIPTION
Very small "fix" inserting a warning in the module configuration menu. Unfortunately, the length of the message pushes the text below the radio button. Inline styling and alterations to `config.css` using the CSS property`white-space` are not making a difference, likely due to the label elements being wrapped in a table.

![Screen Shot 2019-07-29 at 4 08 20 PM](https://user-images.githubusercontent.com/20332546/62078830-72b77e80-b21b-11e9-9d8e-69d762a0c781.png)
