### PR TITLE
check GET params to limit the records parsed

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -254,8 +254,18 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         $control_data = REDCap::getData($Proj->project_id, 'array', $record, $fields_utilized, null, null,
-            false, false, false, false, false, false, false, false, false, array(),
-            false, false, false, false, false, false, 'EVENT', false, false, true);
+                                        false, false, false, false, false, false, false, false, false, array(),
+                                        false, false, false, false, false, false, 'EVENT', false, false, true);
+
+        // only assess records which will be shown
+        if ( ($pagenum = $_GET['pagenum']) && ($num_per_page = $_GET['num_per_page']) ) {
+            if ($num_per_page !== 'ALL') {
+                $num_per_page = intval($num_per_page);
+                $index_from = ($pagenum - 1) * $num_per_page;
+                $slice_length = min([$num_per_page, sizeOf($control_data) - $index_from]); // prevent from wrapping over end of $control_data
+                $control_data = (array_slice($control_data, ($pagenum - 1) * $num_per_page, $slice_length, true));
+            }
+        }
 
         if ($record && !isset($control_data[$record])) {
             // Handling new record case.


### PR DESCRIPTION
Addresses #49 

Makes Record Status Dashboard page loads proportional to number of records viewed instead of entire dataset.

Must be tested with a fairly complicated FRSL configuration to be effective. Should be tested with Linear Data Entry Workflow on as well. I have SQL files that (after a quick `sed`) can be `apply_sql_to_db`'d to recreate WARRIOR conditions in a VM (will require fresh VM with edits made to its `max_upload` sizes to bring in even the metadata-only XML).

These changes do not depend on #51.