### PR TITLE
stop processing at "Delete all data on event" row

### DIFF
--- a/js/frsl.js
+++ b/js/frsl.js
@@ -25,8 +25,15 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         var params = getQueryParameters(this.href,this.getAttribute('onclick'));
-        if (!formRenderSkipLogic.formsAccess[params.id][params.event_id][params.page]) {
-            disableForm(this);
+        try {
+            if (!formRenderSkipLogic.formsAccess[params.id][params.event_id][params.page]) {
+                disableForm(this);
+            }
+        } catch (err) {
+            if (this.firstChild.getAttribute('title') === 'Delete this event') {
+                // on record home the final row is "delete all data on event" buttons and should not be processed
+                return;
+            }
         }
     });
 


### PR DESCRIPTION
Addresses an error found in Issue #56:  
On a record home page, FRSL tries to process the "Delete all data on event" buttons and fails because they do not contain the attributes that an actual instrument button does.

This error existed prior to 3.3.8 (it has likely always been happening) but has not affected functionality as it halts the script only after all instruments have been processed.