### PR TITLE
stop using arm as toggle on record_home pages

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -48,7 +48,7 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         // Do not load FRSL on the add/edit record splash page
-        if ( strpos(PAGE, 'DataEntry/record_home.php') !== false && (!$_GET['arm'] || !$_GET['id']) ) {
+        if ( strpos(PAGE, 'DataEntry/record_home.php') !== false && !$_GET['id'] ) {
             return;
         }
 


### PR DESCRIPTION
Address Issue #56 

If editing a record, upon _saving_ changes, when the user is returned to the record_home page for that record, the `arm` parameter is no longer sent as a GET request, causing FRSL to not load.

The `arm` parameter is not needed to avoid loading FRSL on the initial **Add / Edit Records** page, `id` alone is sufficient.