### PR TITLE
instance parameters only appended to URL when appropriate

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -417,10 +417,9 @@ class ExternalModule extends AbstractExternalModule {
                 // Path to the next available form in the current event.
                 $next_step_path = APP_PATH_WEBROOT . 'DataEntry/index.php?pid=' . $Proj->project_id . '&id=' . $record . '&event_id=' . $event_id . '&page=' . $next_instrument;
 
-                // If a repeating instrument immediately follows another repeating instrument, maintain the instance
+                // If this is a repeating event, maintain the instance
                 if ($Proj->hasRepeatingFormsEvents() && $instance) {
-                    $this_event_repeating_forms = $Proj->getRepeatingFormsEvents()[$event_id];
-                    if ( array_key_exists($instrument, $this_event_repeating_forms) && array_key_exists($next_instrument, $this_event_repeating_forms) ) {
+                    if ($Proj->RepeatingFormsEvents[$event_id] == "WHOLE") {
                         $next_step_path .= '&instance=' . $instance;
                     }
                 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -415,7 +415,15 @@ class ExternalModule extends AbstractExternalModule {
 
             if (isset($next_instrument)) {
                 // Path to the next available form in the current event.
-                $next_step_path = APP_PATH_WEBROOT . 'DataEntry/index.php?pid=' . $Proj->project_id . '&id=' . $record . '&event_id=' . $event_id . '&page=' . $next_instrument . '&instance=' . $instance;
+                $next_step_path = APP_PATH_WEBROOT . 'DataEntry/index.php?pid=' . $Proj->project_id . '&id=' . $record . '&event_id=' . $event_id . '&page=' . $next_instrument;
+
+                // If a repeating instrument immediately follows another repeating instrument, maintain the instance
+                if ($Proj->hasRepeatingFormsEvents() && $instance) {
+                    $this_event_repeating_forms = $Proj->getRepeatingFormsEvents()[$event_id];
+                    if ( array_key_exists($instrument, $this_event_repeating_forms) && array_key_exists($next_instrument, $this_event_repeating_forms) ) {
+                        $next_step_path .= '&instance=' . $instance;
+                    }
+                }
             }
 
             // Access denied to the current page.

--- a/samples/FRSLTestWithAllRepeats_for_issue_41.xml
+++ b/samples/FRSLTestWithAllRepeats_for_issue_41.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="FRSL test 2 with all repeat" AsOfDateTime="2020-03-20T16:19:43" CreationDateTime="2020-03-20T16:19:43" SourceSystem="REDCap" SourceSystemVersion="9.7.0">
+<Study OID="Project.FRSLTest2WithAllRepeat">
+<GlobalVariables>
+	<StudyName>FRSL test 2 with all repeat</StudyName>
+	<StudyDescription>This file contains the metadata, events, and data for REDCap project "FRSL test 2 with all repeat".</StudyDescription>
+	<ProtocolName>FRSL test 2 with all repeat</ProtocolName>
+	<redcap:RecordAutonumberingEnabled>1</redcap:RecordAutonumberingEnabled>
+	<redcap:CustomRecordLabel></redcap:CustomRecordLabel>
+	<redcap:SecondaryUniqueField></redcap:SecondaryUniqueField>
+	<redcap:SchedulingEnabled>0</redcap:SchedulingEnabled>
+	<redcap:SurveysEnabled>0</redcap:SurveysEnabled>
+	<redcap:SurveyInvitationEmailField></redcap:SurveyInvitationEmailField>
+	<redcap:Purpose>0</redcap:Purpose>
+	<redcap:PurposeOther></redcap:PurposeOther>
+	<redcap:ProjectNotes></redcap:ProjectNotes>
+	<redcap:MissingDataCodes></redcap:MissingDataCodes>
+	<redcap:RepeatingInstrumentsAndEvents>
+		<redcap:RepeatingEvent redcap:UniqueEventName="event_2_arm_1"/>
+	</redcap:RepeatingInstrumentsAndEvents>
+</GlobalVariables>
+<MetaDataVersion OID="Metadata.FRSLTest2WithAllRepeat_2020-03-20_1619" Name="FRSL test 2 with all repeat" redcap:RecordIdField="record_id">
+	<Protocol>
+		<StudyEventRef StudyEventOID="Event.event_1_arm_1" OrderNumber="1" Mandatory="No"/>
+		<StudyEventRef StudyEventOID="Event.event_2_arm_1" OrderNumber="2" Mandatory="No"/>
+		<StudyEventRef StudyEventOID="Event.event_3_arm_1" OrderNumber="3" Mandatory="No"/>
+	</Protocol>
+	<StudyEventDef OID="Event.event_1_arm_1" Name="Event 1" Type="Common" Repeating="No" redcap:EventName="Event 1" redcap:CustomEventLabel="" redcap:UniqueEventName="event_1_arm_1" redcap:ArmNum="1" redcap:ArmName="Arm 1" redcap:DayOffset="1" redcap:OffsetMin="0" redcap:OffsetMax="0">
+		<FormRef FormOID="Form.instrument_1" OrderNumber="1" Mandatory="No" redcap:FormName="instrument_1"/>
+		<FormRef FormOID="Form.instrument_2" OrderNumber="2" Mandatory="No" redcap:FormName="instrument_2"/>
+	</StudyEventDef>
+	<StudyEventDef OID="Event.event_2_arm_1" Name="Event 2" Type="Common" Repeating="No" redcap:EventName="Event 2" redcap:CustomEventLabel="" redcap:UniqueEventName="event_2_arm_1" redcap:ArmNum="1" redcap:ArmName="Arm 1" redcap:DayOffset="2" redcap:OffsetMin="0" redcap:OffsetMax="0">
+		<FormRef FormOID="Form.instrument_1" OrderNumber="1" Mandatory="No" redcap:FormName="instrument_1"/>
+		<FormRef FormOID="Form.instrument_2" OrderNumber="2" Mandatory="No" redcap:FormName="instrument_2"/>
+	</StudyEventDef>
+	<StudyEventDef OID="Event.event_3_arm_1" Name="Event 3" Type="Common" Repeating="No" redcap:EventName="Event 3" redcap:CustomEventLabel="" redcap:UniqueEventName="event_3_arm_1" redcap:ArmNum="1" redcap:ArmName="Arm 1" redcap:DayOffset="3" redcap:OffsetMin="0" redcap:OffsetMax="0">
+		<FormRef FormOID="Form.instrument_1" OrderNumber="1" Mandatory="No" redcap:FormName="instrument_1"/>
+		<FormRef FormOID="Form.instrument_2" OrderNumber="2" Mandatory="No" redcap:FormName="instrument_2"/>
+	</StudyEventDef>
+	<FormDef OID="Form.instrument_0" Name="Instrument 0" Repeating="No" redcap:FormName="instrument_0">
+		<ItemGroupRef ItemGroupOID="instrument_0.record_id" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="instrument_0.instrument_0_complete" Mandatory="No"/>
+	</FormDef>
+	<FormDef OID="Form.instrument_1" Name="Instrument 1" Repeating="No" redcap:FormName="instrument_1">
+		<ItemGroupRef ItemGroupOID="instrument_1.age" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="instrument_1.instrument_1_complete" Mandatory="No"/>
+	</FormDef>
+	<FormDef OID="Form.instrument_2" Name="Instrument 2" Repeating="No" redcap:FormName="instrument_2">
+		<ItemGroupRef ItemGroupOID="instrument_2.notes" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="instrument_2.instrument_2_complete" Mandatory="No"/>
+	</FormDef>
+	<ItemGroupDef OID="instrument_0.record_id" Name="Instrument 0" Repeating="No">
+		<ItemRef ItemOID="record_id" Mandatory="No" redcap:Variable="record_id"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_0.instrument_0_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="instrument_0_complete" Mandatory="No" redcap:Variable="instrument_0_complete"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_1.age" Name="Instrument 1" Repeating="No">
+		<ItemRef ItemOID="age" Mandatory="No" redcap:Variable="age"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_1.instrument_1_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="instrument_1_complete" Mandatory="No" redcap:Variable="instrument_1_complete"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_2.notes" Name="Instrument 2" Repeating="No">
+		<ItemRef ItemOID="notes" Mandatory="No" redcap:Variable="notes"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_2.instrument_2_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="instrument_2_complete" Mandatory="No" redcap:Variable="instrument_2_complete"/>
+	</ItemGroupDef>
+	<ItemDef OID="record_id" Name="record_id" DataType="text" Length="999" redcap:Variable="record_id" redcap:FieldType="text">
+		<Question><TranslatedText>Record ID</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="instrument_0_complete" Name="instrument_0_complete" DataType="text" Length="1" redcap:Variable="instrument_0_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="instrument_0_complete.choices"/>
+	</ItemDef>
+	<ItemDef OID="age" Name="age" DataType="integer" Length="999" redcap:Variable="age" redcap:FieldType="text" redcap:TextValidationType="int">
+		<Question><TranslatedText>How old are you?</TranslatedText></Question>
+		<RangeCheck Comparator="GE" SoftHard="Soft">
+			<CheckValue>0</CheckValue>
+			<ErrorMessage><TranslatedText>The value you provided is outside the suggested range. (0 - 120). This value is admissible, but you may wish to double check it.</TranslatedText></ErrorMessage>
+		</RangeCheck>
+		<RangeCheck Comparator="LE" SoftHard="Soft">
+			<CheckValue>120</CheckValue>
+			<ErrorMessage><TranslatedText>The value you provided is outside the suggested range. (0 - 120). This value is admissible, but you may wish to double check it.</TranslatedText></ErrorMessage>
+		</RangeCheck>
+	</ItemDef>
+	<ItemDef OID="instrument_1_complete" Name="instrument_1_complete" DataType="text" Length="1" redcap:Variable="instrument_1_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="instrument_1_complete.choices"/>
+	</ItemDef>
+	<ItemDef OID="notes" Name="notes" DataType="text" Length="999" redcap:Variable="notes" redcap:FieldType="textarea">
+		<Question><TranslatedText>Notes</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="instrument_2_complete" Name="instrument_2_complete" DataType="text" Length="1" redcap:Variable="instrument_2_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="instrument_2_complete.choices"/>
+	</ItemDef>
+	<CodeList OID="instrument_0_complete.choices" Name="instrument_0_complete" DataType="text" redcap:Variable="instrument_0_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="instrument_1_complete.choices" Name="instrument_1_complete" DataType="text" redcap:Variable="instrument_1_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="instrument_2_complete.choices" Name="instrument_2_complete" DataType="text" redcap:Variable="instrument_2_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+</MetaDataVersion>
+</Study>
+</ODM>

--- a/samples/FRSLTestWithRepeatingInstrument_for_issue_67.xml
+++ b/samples/FRSLTestWithRepeatingInstrument_for_issue_67.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="Bug - Repeatable Instrument and Form Render Skip Logic - March 3, 2020" AsOfDateTime="2020-03-03T16:37:27" CreationDateTime="2020-03-03T16:37:27" SourceSystem="REDCap" SourceSystemVersion="9.5.14">
+<Study OID="Project.BugRepeatableInstrumentAndForm">
+<GlobalVariables>
+	<StudyName>Bug - Repeatable Instrument and Form Render Skip Logic - March 3, 2020</StudyName>
+	<StudyDescription>This file contains the metadata, events, and data for REDCap project "Bug - Repeatable Instrument and Form Render Skip Logic - March 3, 2020".</StudyDescription>
+	<ProtocolName>Bug - Repeatable Instrument and Form Render Skip Logic - March 3, 2020</ProtocolName>
+	<redcap:RecordAutonumberingEnabled>1</redcap:RecordAutonumberingEnabled>
+	<redcap:CustomRecordLabel></redcap:CustomRecordLabel>
+	<redcap:SecondaryUniqueField></redcap:SecondaryUniqueField>
+	<redcap:SchedulingEnabled>0</redcap:SchedulingEnabled>
+	<redcap:SurveysEnabled>0</redcap:SurveysEnabled>
+	<redcap:SurveyInvitationEmailField></redcap:SurveyInvitationEmailField>
+	<redcap:Purpose>4</redcap:Purpose>
+	<redcap:PurposeOther></redcap:PurposeOther>
+	<redcap:ProjectNotes></redcap:ProjectNotes>
+	<redcap:MissingDataCodes></redcap:MissingDataCodes>
+	<redcap:RepeatingInstrumentsAndEvents>
+		<redcap:RepeatingInstruments>
+			<redcap:RepeatingInstrument redcap:UniqueEventName="event_1_arm_1" redcap:RepeatInstrument="repeatable_instrument_1" redcap:CustomLabel=""/>
+		</redcap:RepeatingInstruments>
+	</redcap:RepeatingInstrumentsAndEvents>
+</GlobalVariables>
+<MetaDataVersion OID="Metadata.BugRepeatableInstrumentAndForm_2020-03-03_1637" Name="Bug - Repeatable Instrument and Form Render Skip Logic - March 3, 2020" redcap:RecordIdField="record_id">
+	<FormDef OID="Form.instrument_1" Name="Instrument 1" Repeating="No" redcap:FormName="instrument_1">
+		<ItemGroupRef ItemGroupOID="instrument_1.record_id" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="instrument_1.instrument_1_complete" Mandatory="No"/>
+	</FormDef>
+	<FormDef OID="Form.repeatable_instrument_1" Name="Repeatable Instrument 1" Repeating="No" redcap:FormName="repeatable_instrument_1">
+		<ItemGroupRef ItemGroupOID="repeatable_instrument_1.notes" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="repeatable_instrument_1.repeatable_instrument_1_complete" Mandatory="No"/>
+	</FormDef>
+	<FormDef OID="Form.instrument_2" Name="Instrument 2" Repeating="No" redcap:FormName="instrument_2">
+		<ItemGroupRef ItemGroupOID="instrument_2.is_taking_vitamins" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="instrument_2.instrument_2_complete" Mandatory="No"/>
+	</FormDef>
+	<ItemGroupDef OID="instrument_1.record_id" Name="Instrument 1" Repeating="No">
+		<ItemRef ItemOID="record_id" Mandatory="No" redcap:Variable="record_id"/>
+		<ItemRef ItemOID="age" Mandatory="No" redcap:Variable="age"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_1.instrument_1_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="instrument_1_complete" Mandatory="No" redcap:Variable="instrument_1_complete"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="repeatable_instrument_1.notes" Name="Repeatable Instrument 1" Repeating="No">
+		<ItemRef ItemOID="notes" Mandatory="No" redcap:Variable="notes"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="repeatable_instrument_1.repeatable_instrument_1_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="repeatable_instrument_1_complete" Mandatory="No" redcap:Variable="repeatable_instrument_1_complete"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_2.is_taking_vitamins" Name="Instrument 2" Repeating="No">
+		<ItemRef ItemOID="is_taking_vitamins" Mandatory="No" redcap:Variable="is_taking_vitamins"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="instrument_2.instrument_2_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="instrument_2_complete" Mandatory="No" redcap:Variable="instrument_2_complete"/>
+	</ItemGroupDef>
+	<ItemDef OID="record_id" Name="record_id" DataType="text" Length="999" redcap:Variable="record_id" redcap:FieldType="text">
+		<Question><TranslatedText>Record ID</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="age" Name="age" DataType="integer" Length="999" redcap:Variable="age" redcap:FieldType="text" redcap:TextValidationType="int">
+		<Question><TranslatedText>How old are you?</TranslatedText></Question>
+		<RangeCheck Comparator="GE" SoftHard="Soft">
+			<CheckValue>0</CheckValue>
+			<ErrorMessage><TranslatedText>The value you provided is outside the suggested range. (0 - 120). This value is admissible, but you may wish to double check it.</TranslatedText></ErrorMessage>
+		</RangeCheck>
+		<RangeCheck Comparator="LE" SoftHard="Soft">
+			<CheckValue>120</CheckValue>
+			<ErrorMessage><TranslatedText>The value you provided is outside the suggested range. (0 - 120). This value is admissible, but you may wish to double check it.</TranslatedText></ErrorMessage>
+		</RangeCheck>
+	</ItemDef>
+	<ItemDef OID="instrument_1_complete" Name="instrument_1_complete" DataType="text" Length="1" redcap:Variable="instrument_1_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="instrument_1_complete.choices"/>
+	</ItemDef>
+	<ItemDef OID="notes" Name="notes" DataType="text" Length="999" redcap:Variable="notes" redcap:FieldType="textarea">
+		<Question><TranslatedText>Notes</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="repeatable_instrument_1_complete" Name="repeatable_instrument_1_complete" DataType="text" Length="1" redcap:Variable="repeatable_instrument_1_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="repeatable_instrument_1_complete.choices"/>
+	</ItemDef>
+	<ItemDef OID="is_taking_vitamins" Name="is_taking_vitamins" DataType="boolean" Length="1" redcap:Variable="is_taking_vitamins" redcap:FieldType="yesno">
+		<Question><TranslatedText>Do you take vitamin supplements?</TranslatedText></Question>
+		<CodeListRef CodeListOID="is_taking_vitamins.choices"/>
+	</ItemDef>
+	<ItemDef OID="instrument_2_complete" Name="instrument_2_complete" DataType="text" Length="1" redcap:Variable="instrument_2_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="instrument_2_complete.choices"/>
+	</ItemDef>
+	<CodeList OID="instrument_1_complete.choices" Name="instrument_1_complete" DataType="text" redcap:Variable="instrument_1_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="repeatable_instrument_1_complete.choices" Name="repeatable_instrument_1_complete" DataType="text" redcap:Variable="repeatable_instrument_1_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="is_taking_vitamins.choices" Name="is_taking_vitamins" DataType="boolean" redcap:Variable="is_taking_vitamins">
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Yes</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>No</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="instrument_2_complete.choices" Name="instrument_2_complete" DataType="text" redcap:Variable="instrument_2_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+</MetaDataVersion>
+</Study>
+</ODM>


### PR DESCRIPTION
Addresses issue #67

An `instance` parameter will only be added to `next_step_path` if ALL criteria are met:

- The user is on a repeating instrument
- The next instrument is within the same event and is also a repeating instrument

~~A possible improvement may be to detect if the next instrument has any existing instances before appending the `instance` parameter.~~ This is not how repeating forms are expected to work.

___
UPDATE: 

An `instance` parameter will only be added to `next_step_path` if ALL criteria are met:

- The user is on form in a repeating _event_
- They are already working on an instance > 1