### PR TITLE
update min RC version to 8.7.2 to ensure all core lib functions exist

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,16 +22,6 @@
             "institution": "University of Florida - CTSI"
         },
         {
-            "name": "Marly Cormar",
-            "email": "marlycormar@ufl.edu",
-            "institution": "University of Florida - CTSI"
-        },
-        {
-            "name": "Tiago Bember",
-            "email": "tbembersimeao@ufl.edu",
-            "institution": "University of Florida - CTSI"
-        },
-        {
             "name": "Kyle Chesney",
             "email": "kyle.chesney@ufl.edu",
             "institution": "University of Florida - CTSI"

--- a/config.json
+++ b/config.json
@@ -149,6 +149,6 @@
         }
     ],
     "compatibility": {
-        "redcap-version-min": "8.4.3"
+        "redcap-version-min": "8.7.2"
     }
 }


### PR DESCRIPTION
Addresses issue #71 

Tested with 8.7.2, `redcap_hook_every_page_top` error did not occur after starting a new project and turning on this module.